### PR TITLE
Move the gpg and nexus-release plugins to a 'release' profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ publish: git-is-clean git-is-master git-pull-needed
 		sed -i '' 's!<apigen\.version>.*</apigen\.version>!<apigen.version>'$(NEW_VERSION)'</apigen.version>!' apigen/src/test/projects/*/pom.xml && \
 		git commit -am '[skip ci][release:prepare] prepare release $(PACKAGE_NAME)-$(NEW_VERSION)' && \
 		git tag -m 'Preparing new release $(PACKAGE_NAME)-$(NEW_VERSION)' -a '$(PACKAGE_NAME)-$(NEW_VERSION)' && \
-		mvn clean test deploy && \
+		mvn clean test deploy -Prelease && \
 		mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$(NEXT_SNAPSHOT) && \
 		sed -i '' 's!<apigen\.version>.*</apigen\.version>!<apigen.version>'$(NEXT_SNAPSHOT)'</apigen.version>!' apigen/src/test/projects/*/pom.xml && \
 		git commit -am '[skip ci][release:perform] prepare for next development iteration' && \

--- a/pom.xml
+++ b/pom.xml
@@ -132,31 +132,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.6</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <stagingProfileId>2b56e464b6a033</stagingProfileId>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
         <executions>
@@ -206,4 +181,41 @@
       <comments>A business-friendly OSS license</comments>
     </license>
   </licenses>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.6</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <stagingProfileId>2b56e464b6a033</stagingProfileId>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
People trying to contribute to the project shouldn't need (or want) to use gpg or the nexus release plugin, only people releasing it to maven central