### PR TITLE
Mapping GraphQL Float data type to Double in Java

### DIFF
--- a/apigen/src/main/java/com/distelli/graphql/apigen/STModel.java
+++ b/apigen/src/main/java/com/distelli/graphql/apigen/STModel.java
@@ -45,6 +45,7 @@ public class STModel {
             put("Int", "Integer");
             put("ID", "String");
             put("Char", "Character");
+            put("Float", "Double");
         }};
     public static class Builder {
         private TypeEntry typeEntry;


### PR DESCRIPTION
According to the specification of graphql-java Float type should mapped as Double.

https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/Scalars.java#L122

The problem actually is that when a getXXX method defined as Float in the GraphQL IDL we get cast exception as the graphql parser stores it as Double.